### PR TITLE
Add support to add/remove transaction from past/future and update history data

### DIFF
--- a/backend/src/controllers/__tests__/expense-controller.test.ts
+++ b/backend/src/controllers/__tests__/expense-controller.test.ts
@@ -1,0 +1,285 @@
+import { NextFunction, Request } from "express";
+import supertest from "supertest";
+import server from "../../server";
+import {
+  createAccount,
+  findAccountsById,
+} from "../../services/account-service";
+import { IAccountModel } from "../../models/account-model";
+import {
+  createTransaction,
+  findExpenseTransactionsByUser,
+  findTransactionById,
+} from "../../services/transaction-service";
+import { ITransactionModel } from "../../models/transaction-model";
+
+const api = supertest(server);
+
+const SIMPLE_ACCOUNT: IAccount = {
+  name: "simple account",
+  type: "cash",
+  balance: 1000.0,
+};
+
+const SIMPLE_TRANSACTION = {
+  description: "123",
+  amount: 100,
+  date: "2020-11-10T00:00:00.000Z",
+};
+
+const SIMPLE_TRANSACTION_AFTER = {
+  ...SIMPLE_TRANSACTION,
+  date: "2020-11-11T00:00:00.000Z",
+};
+
+const SIMPLE_TRANSACTION_BEFORE = {
+  ...SIMPLE_TRANSACTION,
+  date: "2020-11-09T00:00:00.000Z",
+};
+
+const USER_ID = "5faef3d6498b721318cbdc51";
+const OTHER_USER_ID = "5faef3d6498b721318cbdc55";
+
+jest.mock(
+  "../../routes/middlewares/authenticationCheck",
+  () => (req: Request, res: never, next: NextFunction) => {
+    const user = { _id: USER_ID, id: USER_ID };
+    req.user = user;
+    next();
+  }
+);
+
+describe("Expense endpoint", () => {
+  test("GET /api/expense should return user own expenses", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1000,
+    } as IAccountModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      fromAccountBalance: 1000,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      fromAccountBalance: 900,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: OTHER_USER_ID,
+      amount: 100,
+      fromAccountBalance: 800,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const { body: expenses }: { body: IExpense[] } = await api
+      .get(`/api/expense`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+
+    expect(expenses.length).toEqual(2);
+  });
+
+  test("GET /api/expense/EXPENSE-ID should should show only own expenses", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1000,
+    } as IAccountModel);
+
+    const ownExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      fromAccountBalance: 1000,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const notOwnExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: OTHER_USER_ID,
+      amount: 100,
+      fromAccountBalance: 800,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await api
+      .get(`/api/expense/${ownExpense?._id}`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+    await api
+      .get(`/api/expense/${notOwnExpense?._id}`)
+      .expect(403)
+      .expect("Content-Type", /application\/json/);
+  });
+
+  test("POST /api/expense should add expense and decrease account balance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1000,
+    } as IAccountModel);
+
+    const {
+      body: { payload: newExpense },
+    }: { body: IApiResponse<IExpense> } = await api
+      .post(`/api/expense`)
+      .send({
+        ...SIMPLE_TRANSACTION,
+        user: USER_ID,
+        amount: 100,
+        fromAccount: testAccount?._id,
+      } as ITransactionModel)
+      .expect(201)
+      .expect("Content-Type", /application\/json/);
+
+    const expenses = await findExpenseTransactionsByUser(USER_ID);
+    const testAccountAfter = await findAccountsById(testAccount?._id);
+    expect(newExpense.fromAccountBalance).toEqual(testAccount?.balance);
+    expect(expenses?.length).toEqual(1);
+    expect(testAccountAfter?.balance).toEqual(900);
+  });
+
+  test("DELETE /api/expense/EXPENSE-ID should remove expense and increase account balance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 900,
+    } as IAccountModel);
+
+    const ownExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      fromAccountBalance: 1000,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const notOwnExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: OTHER_USER_ID,
+      amount: 100,
+      fromAccountBalance: 800,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const expensesBefore = await findExpenseTransactionsByUser(USER_ID);
+    expect(expensesBefore?.length).toEqual(1);
+
+    await api
+      .delete(`/api/expense/${ownExpense?._id}`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+    await api
+      .delete(`/api/expense/${notOwnExpense?._id}`)
+      .expect(403)
+      .expect("Content-Type", /application\/json/);
+
+    const expensesAfter = await findExpenseTransactionsByUser(USER_ID);
+    const testAccountAfter = await findAccountsById(testAccount?._id);
+    expect(expensesAfter?.length).toEqual(0);
+    expect(testAccountAfter?.balance).toEqual(1000);
+  });
+
+  test("DELETE /api/expense/EXPENSE-ID should increase newer expense fromAccountBalance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 800,
+    } as IAccountModel);
+
+    const firstTransaction = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      fromAccountBalance: 1000,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+    const secondTransaction = await createTransaction({
+      ...SIMPLE_TRANSACTION_AFTER,
+      user: USER_ID,
+      amount: 100,
+      fromAccountBalance: 900,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await api
+      .delete(`/api/expense/${firstTransaction?._id}`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+
+    const secondTransactionAfter = await findTransactionById(
+      secondTransaction?._id
+    );
+
+    expect(secondTransactionAfter?.fromAccountBalance).toEqual(1000);
+  });
+
+  test("POST /api/expense when add past expense should decrease newer expense fromAcountBalance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 950,
+    } as IAccountModel);
+
+    const existingExpenseAfterNewExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION_AFTER,
+      user: USER_ID,
+      amount: 100,
+      fromAccountBalance: 1000,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const existingExpenseBeforeNewExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION_BEFORE,
+      user: USER_ID,
+      amount: 500,
+      fromAccountBalance: 1500,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION_AFTER,
+      user: USER_ID,
+      amount: 50,
+      toAccountBalance: 900,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const {
+      body: { payload: newExpense },
+    } = await api
+      .post(`/api/expense`)
+      .send({
+        ...SIMPLE_TRANSACTION,
+        user: USER_ID,
+        amount: 100,
+        fromAccount: testAccount?._id,
+      } as ITransactionModel)
+      .expect(201)
+      .expect("Content-Type", /application\/json/);
+
+    const existingIncomeAfterNewExpenseAfterInsertNewExpense = await findTransactionById(
+      existingExpenseAfterNewExpense?._id
+    );
+    const existingIncomeBeforeNewExpenseAfterInsertNewExpense = await findTransactionById(
+      existingExpenseBeforeNewExpense?._id
+    );
+    expect(
+      existingIncomeAfterNewExpenseAfterInsertNewExpense?.fromAccountBalance
+    ).toEqual(900);
+    expect(
+      existingIncomeBeforeNewExpenseAfterInsertNewExpense?.fromAccountBalance
+    ).toEqual(1500);
+    expect(newExpense?.fromAccountBalance).toEqual(1000);
+  });
+});

--- a/backend/src/controllers/__tests__/income-controller.test.ts
+++ b/backend/src/controllers/__tests__/income-controller.test.ts
@@ -1,0 +1,285 @@
+import { NextFunction, Request } from "express";
+import supertest from "supertest";
+import server from "../../server";
+import {
+  createAccount,
+  findAccountsById,
+} from "../../services/account-service";
+import { IAccountModel } from "../../models/account-model";
+import {
+  createTransaction,
+  findIncomeTransactionsByUser,
+  findTransactionById,
+} from "../../services/transaction-service";
+import { ITransactionModel } from "../../models/transaction-model";
+
+const api = supertest(server);
+
+const SIMPLE_ACCOUNT: IAccount = {
+  name: "simple account",
+  type: "cash",
+  balance: 1000.0,
+};
+
+const SIMPLE_TRANSACTION = {
+  description: "123",
+  amount: 100,
+  date: "2020-11-10T00:00:00.000Z",
+};
+
+const SIMPLE_TRANSACTION_AFTER = {
+  ...SIMPLE_TRANSACTION,
+  date: "2020-11-11T00:00:00.000Z",
+};
+
+const SIMPLE_TRANSACTION_BEFORE = {
+  ...SIMPLE_TRANSACTION,
+  date: "2020-11-09T00:00:00.000Z",
+};
+
+const USER_ID = "5faef3d6498b721318cbdc51";
+const OTHER_USER_ID = "5faef3d6498b721318cbdc55";
+
+jest.mock(
+  "../../routes/middlewares/authenticationCheck",
+  () => (req: Request, res: never, next: NextFunction) => {
+    const user = { _id: USER_ID, id: USER_ID };
+    req.user = user;
+    next();
+  }
+);
+
+describe("Income endpoint", () => {
+  test("GET /api/income should return user own incomes", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1000,
+    } as IAccountModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      toAccountBalance: 1000,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      toAccountBalance: 1100,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: OTHER_USER_ID,
+      amount: 100,
+      toAccountBalance: 1200,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const { body: incomes }: { body: IIncome[] } = await api
+      .get(`/api/income`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+
+    expect(incomes.length).toEqual(2);
+  });
+
+  test("GET /api/income/INCOME-ID should should show only own incomes", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1000,
+    } as IAccountModel);
+
+    const ownIncome = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      toAccountBalance: 1000,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const notOwnIncome = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: OTHER_USER_ID,
+      amount: 100,
+      toAccountBalance: 1100,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await api
+      .get(`/api/income/${ownIncome?._id}`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+    await api
+      .get(`/api/income/${notOwnIncome?._id}`)
+      .expect(403)
+      .expect("Content-Type", /application\/json/);
+  });
+
+  test("POST /api/income should add income and increase account balance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1000,
+    } as IAccountModel);
+
+    const {
+      body: { payload: newIncome },
+    }: { body: IApiResponse<IIncome> } = await api
+      .post(`/api/income`)
+      .send({
+        ...SIMPLE_TRANSACTION,
+        user: USER_ID,
+        amount: 100,
+        toAccount: testAccount?._id,
+      } as ITransactionModel)
+      .expect(201)
+      .expect("Content-Type", /application\/json/);
+
+    const incomes = await findIncomeTransactionsByUser(USER_ID);
+    const testAccountAfter = await findAccountsById(testAccount?._id);
+    expect(newIncome.toAccountBalance).toEqual(testAccount?.balance);
+    expect(incomes?.length).toEqual(1);
+    expect(testAccountAfter?.balance).toEqual(1100);
+  });
+
+  test("DELETE /api/income/INCOME-ID should remove own income and decrease account balance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 900,
+    } as IAccountModel);
+
+    const ownIncome = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      toAccountBalance: 1000,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const notOwnIncome = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: OTHER_USER_ID,
+      amount: 100,
+      toAccountBalance: 800,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const incomesBefore = await findIncomeTransactionsByUser(USER_ID);
+    expect(incomesBefore?.length).toEqual(1);
+
+    await api
+      .delete(`/api/income/${ownIncome?._id}`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+    await api
+      .delete(`/api/income/${notOwnIncome?._id}`)
+      .expect(403)
+      .expect("Content-Type", /application\/json/);
+
+    const incomesAfter = await findIncomeTransactionsByUser(USER_ID);
+    const testAccountAfter = await findAccountsById(testAccount?._id);
+    expect(incomesAfter?.length).toEqual(0);
+    expect(testAccountAfter?.balance).toEqual(800);
+  });
+
+  test("DELETE /api/income/INCOME-ID should decrease newer income toAccountBalance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1000,
+    } as IAccountModel);
+
+    const firstTransaction = await createTransaction({
+      ...SIMPLE_TRANSACTION,
+      user: USER_ID,
+      amount: 100,
+      toAccountBalance: 800,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+    const secondTransaction = await createTransaction({
+      ...SIMPLE_TRANSACTION_AFTER,
+      user: USER_ID,
+      amount: 100,
+      toAccountBalance: 900,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await api
+      .delete(`/api/income/${firstTransaction?._id}`)
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+
+    const secondTransactionAfter = await findTransactionById(
+      secondTransaction?._id
+    );
+
+    expect(secondTransactionAfter?.toAccountBalance).toEqual(800);
+  });
+
+  test("POST /api/income when add past expense should decrease newer income fromAcountBalance", async () => {
+    const testAccount = await createAccount({
+      ...SIMPLE_ACCOUNT,
+      owner: USER_ID,
+      balance: 1050,
+    } as IAccountModel);
+
+    const existingIncomeBeforeNewExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION_BEFORE,
+      user: USER_ID,
+      amount: 500,
+      toAccountBalance: 500,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const existingIncomeAfterNewExpense = await createTransaction({
+      ...SIMPLE_TRANSACTION_AFTER,
+      user: USER_ID,
+      amount: 100,
+      toAccountBalance: 1000,
+      toAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    await createTransaction({
+      ...SIMPLE_TRANSACTION_AFTER,
+      user: USER_ID,
+      amount: 50,
+      fromAccountBalance: 1100,
+      fromAccount: testAccount?._id,
+    } as ITransactionModel);
+
+    const {
+      body: { payload: newIncome },
+    } = await api
+      .post(`/api/income`)
+      .send({
+        ...SIMPLE_TRANSACTION,
+        user: USER_ID,
+        amount: 100,
+        toAccount: testAccount?._id,
+      } as ITransactionModel)
+      .expect(201)
+      .expect("Content-Type", /application\/json/);
+
+    const existingIncomeAfterNewExpenseAfterInsertNewIncome = await findTransactionById(
+      existingIncomeAfterNewExpense?._id
+    );
+    const existingIncomeBeforeNewExpenseAfterInsertNewIncome = await findTransactionById(
+      existingIncomeBeforeNewExpense?._id
+    );
+    expect(
+      existingIncomeAfterNewExpenseAfterInsertNewIncome?.toAccountBalance
+    ).toEqual(1100);
+    expect(
+      existingIncomeBeforeNewExpenseAfterInsertNewIncome?.toAccountBalance
+    ).toEqual(500);
+    expect(newIncome?.toAccountBalance).toEqual(1000);
+  });
+});

--- a/backend/src/controllers/expense-controller.ts
+++ b/backend/src/controllers/expense-controller.ts
@@ -1,12 +1,9 @@
-import { Response, Request } from "express";
+import { Response, Request, NextFunction } from "express";
 import { ITransactionModel } from "../models/transaction-model";
 
 import { IUserModel } from "../models/user-model";
 import { findAccountsById } from "../services/account-service";
-import {
-  createTransaction,
-  findExpenseTransactionsByUser,
-} from "../services/transaction-service";
+import { findExpenseTransactionsByUser } from "../services/transaction-service";
 
 export const listUserExpenses = async (
   req: Request,
@@ -19,7 +16,8 @@ export const listUserExpenses = async (
 
 export const addExpense = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   const user = req.user as IUserModel;
   const rawNewExpense = req.body as ITransactionModel;
@@ -57,17 +55,5 @@ export const addExpense = async (
     return;
   }
 
-  rawNewExpense.user = user.id;
-  rawNewExpense.fromAccountBalance = sourceAccount?.balance;
-
-  if (sourceAccount) {
-    sourceAccount.balance -= rawNewExpense.amount;
-    await sourceAccount.save();
-  }
-
-  const newTransaction = await createTransaction(rawNewExpense);
-
-  res
-    .status(201)
-    .json({ authorized: true, status: 201, payload: newTransaction });
+  next();
 };

--- a/backend/src/controllers/income-controller.ts
+++ b/backend/src/controllers/income-controller.ts
@@ -1,12 +1,9 @@
-import { Response, Request } from "express";
+import { Response, Request, NextFunction } from "express";
 import { ITransactionModel } from "../models/transaction-model";
 
 import { IUserModel } from "../models/user-model";
 import { findAccountsById } from "../services/account-service";
-import {
-  createTransaction,
-  findIncomeTransactionsByUser,
-} from "../services/transaction-service";
+import { findIncomeTransactionsByUser } from "../services/transaction-service";
 
 export const listUserIncomes = async (
   req: Request,
@@ -17,7 +14,11 @@ export const listUserIncomes = async (
   res.status(200).json(allIncomes);
 };
 
-export const addIncome = async (req: Request, res: Response): Promise<void> => {
+export const addIncome = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   const user = req.user as IUserModel;
   const rawNewIncome = req.body as ITransactionModel;
 
@@ -51,17 +52,5 @@ export const addIncome = async (req: Request, res: Response): Promise<void> => {
     return;
   }
 
-  rawNewIncome.user = user.id;
-  rawNewIncome.toAccountBalance = targetAccount?.balance;
-
-  if (targetAccount) {
-    targetAccount.balance += rawNewIncome.amount;
-    await targetAccount.save();
-  }
-
-  const newTransaction = await createTransaction(rawNewIncome);
-
-  res
-    .status(201)
-    .json({ authorized: true, status: 201, payload: newTransaction });
+  next();
 };

--- a/backend/src/routes/expense-route.ts
+++ b/backend/src/routes/expense-route.ts
@@ -6,13 +6,14 @@ import {
 import {
   getTransaction,
   deleteTransaction,
+  addTransaction,
 } from "../controllers/transaction-controller";
 
 const router = Router();
 
 router.get("/", listUserExpenses);
 
-router.post("/", addExpense);
+router.post("/", addExpense, addTransaction);
 
 router.get("/:id", getTransaction);
 

--- a/backend/src/routes/income-route.ts
+++ b/backend/src/routes/income-route.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { addIncome, listUserIncomes } from "../controllers/income-controller";
 import {
+  addTransaction,
   deleteTransaction,
   getTransaction,
 } from "../controllers/transaction-controller";
@@ -9,7 +10,7 @@ const router = Router();
 
 router.get("/", listUserIncomes);
 
-router.post("/", addIncome);
+router.post("/", addIncome, addTransaction);
 
 router.get("/:id", getTransaction);
 

--- a/backend/src/routes/transaction-route.ts
+++ b/backend/src/routes/transaction-route.ts
@@ -1,12 +1,13 @@
 import { Router } from "express";
 import {
   addTransaction,
+  addTransfer,
   getTransfers,
 } from "../controllers/transaction-controller";
 
 const router = Router();
 
-router.post("/", addTransaction);
+router.post("/", addTransfer, addTransaction);
 
 router.get("/transfers", getTransfers);
 

--- a/backend/src/services/transaction-service.ts
+++ b/backend/src/services/transaction-service.ts
@@ -51,6 +51,22 @@ export const findTransactionsByAccount = async (
     ],
   });
 
+export const findTransactionsAfterByAccount = async (
+  accountId: string,
+  date: Date
+): Promise<ITransactionModel[] | null> =>
+  transactionModel.find({
+    date: { $gt: date },
+    $or: [
+      {
+        fromAccount: accountId,
+      },
+      {
+        toAccount: accountId,
+      },
+    ],
+  });
+
 export const findTransactionsByUser = async (
   userId: string
 ): Promise<ITransactionModel[] | null> =>
@@ -62,3 +78,18 @@ export const findTransactionsByUser = async (
 export const DANGER_truncateTransactionsByUser = async (
   userId: string
 ): Promise<void> => transactionModel.deleteMany({ user: userId });
+
+export const increaseAccountTransactionBalanceAfterTargetDate = async (
+  accountId: string,
+  date: Date,
+  amount: number
+): Promise<void> => {
+  await transactionModel.updateMany(
+    { fromAccount: accountId, date: { $gt: date } },
+    { $inc: { fromAccountBalance: amount } }
+  );
+  await transactionModel.updateMany(
+    { toAccount: accountId, date: { $gt: date } },
+    { $inc: { toAccountBalance: amount } }
+  );
+};


### PR DESCRIPTION
With this history manipulation we get proper history data for account balance tracking
even if we don't add all transactions in sync with timeline