### PR TITLE
Safari fix for date parsing

### DIFF
--- a/packages/frontend/src/pages/statistics/Statistics.tsx
+++ b/packages/frontend/src/pages/statistics/Statistics.tsx
@@ -72,7 +72,7 @@ export const Statistics = (): JSX.Element => {
 
   const handleMonthOptionChange = (direction: 'next' | 'previous') => {
     const { month, year } = monthFilterOptions;
-    const monthWithTwoDigits = month.toString().padStart(2, "0");
+    const monthWithTwoDigits = month.toString().padStart(2, '0');
     const selectedMonth = new Date(`${year}-${monthWithTwoDigits}-01`);
 
     selectedMonth.setMonth(

--- a/packages/frontend/src/pages/statistics/Statistics.tsx
+++ b/packages/frontend/src/pages/statistics/Statistics.tsx
@@ -72,7 +72,8 @@ export const Statistics = (): JSX.Element => {
 
   const handleMonthOptionChange = (direction: 'next' | 'previous') => {
     const { month, year } = monthFilterOptions;
-    const selectedMonth = new Date(`${year}-${month}-01`);
+    const monthWithTwoDigits = month.toString().padStart(2, "0");
+    const selectedMonth = new Date(`${year}-${monthWithTwoDigits}-01`);
 
     selectedMonth.setMonth(
       selectedMonth.getMonth() + (direction === 'next' ? 1 : -1)


### PR DESCRIPTION
By some reason safari need date in `YYYY-MM-DD` format to work so previous format `YYYY-M-DD` caused error and invalid date object